### PR TITLE
Remove numbers from puzzle tiles

### DIFF
--- a/script.js
+++ b/script.js
@@ -50,7 +50,8 @@ class SlidingPuzzle {
                     
                     piece.style.backgroundImage = `url('./images/${this.currentImage}')`;
                     piece.style.backgroundPosition = `-${tileCol * 100}px -${tileRow * 100}px`;
-                    piece.textContent = tileNumber;
+                    // Remove tile numbers to display only the image
+                    piece.textContent = '';
                     
                     piece.addEventListener('click', () => this.moveTile(row, col));
                 }


### PR DESCRIPTION
## Summary
- hide tile numbers so the puzzle only shows the image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fd8680210832698480d2a2c93a878