### PR TITLE
Fix duplicate puzzle render when changing images

### DIFF
--- a/script.js
+++ b/script.js
@@ -157,7 +157,6 @@ class SlidingPuzzle {
 
     changeImage(imageName) {
         this.currentImage = imageName;
-        this.renderPuzzle();
         // When changing image, reset game state including timer
         this.resetGame();
     }


### PR DESCRIPTION
## Summary
- avoid calling `renderPuzzle` twice during image changes by removing the call in `changeImage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883a2a1d47483268680f10d01c71f05